### PR TITLE
Correct the OneGraph main site URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Try it live at [https://www.onegraph.com/graphiql](https://www.onegraph.com/grap
 
 [OneGraph](https://www.onegraph.com) provides easy, consistent access to the APIs that underlie your business--all through the power of GraphQL.
 
-Sign up at [https://www.onegraph.com](onegraph.com).
+Sign up at [https://www.onegraph.com](http://www.onegraph.com).
 
 [![npm version](http://img.shields.io/npm/v/graphiql-explorer.svg?style=flat)](https://npmjs.org/package/graphiql-explorer "View this project on npm")
 


### PR DESCRIPTION
Just wanted to do this fix for you since it doesn't take you to your main site right now. I know most people will likely edit the URL bar but let's make it easy for them to find you 😄 